### PR TITLE
Fix derivedFrom attribute types and enumeratedValue minOccurs

### DIFF
--- a/doxygen/src/svd_schema.txt
+++ b/doxygen/src/svd_schema.txt
@@ -1116,7 +1116,7 @@ Note, you can also specify an array of a cluster using the \tagem{dim} element.
         - No relative paths will work.
         <br><b>Remarks:</b> When deriving a cluster, it is mandatory to specify at least
         the \tagem{name}, the \tagem{description}, and the \tagem{addressOffset}.</td>
-    <td>registerType</td>
+    <td>referenceIdentifierType</td>
     <td>0..1</td>
   </tr>
   <tr>
@@ -1353,7 +1353,7 @@ typedef struct {
         - No relative paths will work.
         <br><b>Remarks:</b> When deriving, it is mandatory to specify at least
         the \tagem{name}, the \tagem{description}, and the \tagem{addressOffset}.</td>
-    <td>xs:Name</td>
+    <td>referenceIdentifierType</td>
     <td>0..1</td>
   </tr>
   <tr>
@@ -1764,7 +1764,7 @@ A field may define an \em enumeratedValue in order to make the display more intu
         - No relative paths will work.
         <br><b>Remarks:</b> When deriving, it is mandatory to specify at least
         the \tagem{name} and \tagem{description}.</td>
-    <td>xs:Name</td>
+    <td>referenceIdentifierType</td>
     <td>0..1</td>
   </tr>
   <tr>
@@ -1992,7 +1992,7 @@ can provide reference manual level details within the debugger.
     peripheral + register + field:   timer0.ctrl.clk.dis_en_enum
 </pre>
     </td>
-    <td>xs:Name</td>
+    <td>referenceIdentifierType</td>
     <td>0..1</td>
   </tr>
   <tr>
@@ -2025,9 +2025,9 @@ can provide reference manual level details within the debugger.
   <tr>
     <td>\refelem{enumeratedValue}</td>
     <td>Describes a single entry in the enumeration. The number of required items depends on the
-        bit-width of the associated field.</td>
+        bit-width of the associated field. If derived from a previously defined \em enumeratedValues section, don't specify, else required.</td>
     <td>enumeratedValueType</td>
-    <td>1..*</td>
+    <td>0/1..*</td>
   </tr>
 </table>
 

--- a/schema/CMSIS-SVD.xsd
+++ b/schema/CMSIS-SVD.xsd
@@ -17,8 +17,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  $Date:         20. February 2024
-  $Revision:     1.3.10
+  $Date:         7. June 2024
+  $Revision:     1.3.11
+
+  Version 1.3.11:
+  - add referenceIdentifierType
+  - change minOccurs for element enumeratedValue from 1 to 0 to allow deriving
+  - change enumeratedValues derivedFrom attribute type to referenceIdentifierType to allow referencing 
+  - change field derivedFrom attribute type to referenceIdentifierType to allow referencing from another scope
+  - change register derivedFrom attribute type to referenceIdentifierType to allow referencing from another scope
+  - change cluster derivedFrom attribute type to referenceIdentifierType to allow referencing from another scope
 
   Version 1.3.10:
   - add CM52 as enumerated value for cpuNameType.
@@ -163,6 +171,12 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <!-- referenceIdentifierType extends the type dimableIdentifierType with referenceability ('.'), which allows referencing in the derivedFrom attribute. -->
+  <xs:simpleType name="referenceIdentifierType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(((%s)|(%s)[_A-Za-z]{1}[_A-Za-z0-9]*)|([_A-Za-z]{1}[_A-Za-z0-9]*(\[%s\])?)|([_A-Za-z]{1}[_A-Za-z0-9]*(%s)?[_A-Za-z0-9]*)){1}(\.(((%s)|(%s)[_A-Za-z]{1}[_A-Za-z0-9]*)|([_A-Za-z]{1}[_A-Za-z0-9]*(\[%s\])?)|([_A-Za-z]{1}[_A-Za-z0-9]*(%s)?[_A-Za-z0-9]*)))*"/>
+    </xs:restriction>
+  </xs:simpleType>
   <!-- dimableIdentifierType specifies the subset and sequence of characters used for specifying identifiers that may contain %s from dim. -->
   <!-- this is particularly important as these are used in ANSI C Structures during the device header file generation -->
   <xs:simpleType name="dimableIdentifierType">
@@ -430,10 +444,10 @@
       <!-- usage specifies whether this enumeration is to be used for read or write or
                                                        (read and write) accesses -->
       <xs:element name="usage" type="enumUsageType" minOccurs="0"/>
-      <!-- enumeratedValue derivedFrom=<identifierType> -->
-      <xs:element name="enumeratedValue" type="enumeratedValueType" minOccurs="1" maxOccurs="unbounded"/>
+      <!-- enumeratedValues derivedFrom=<referenceIdentifierType> -->
+      <xs:element name="enumeratedValue" type="enumeratedValueType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute name="derivedFrom" type="identifierType" use="optional"/>
+    <xs:attribute name="derivedFrom" type="referenceIdentifierType" use="optional"/>
   </xs:complexType>
 
   <xs:complexType name="dimArrayIndexType">
@@ -473,7 +487,7 @@
       <xs:element name="enumeratedValues" type="enumerationType" minOccurs="0" maxOccurs="2">
       </xs:element>
     </xs:sequence>
-    <xs:attribute name="derivedFrom" type="dimableIdentifierType" use="optional"/>
+    <xs:attribute name="derivedFrom" type="referenceIdentifierType" use="optional"/>
   </xs:complexType>
 
   <xs:complexType name="fieldsType">
@@ -519,7 +533,7 @@
       <!-- fields section contains all fields that belong to this register -->
       <xs:element name="fields" type="fieldsType" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
-    <xs:attribute name="derivedFrom" type="dimableIdentifierType" use="optional"/>
+    <xs:attribute name="derivedFrom" type="referenceIdentifierType" use="optional"/>
   </xs:complexType>
 
   <!-- V1.1: A cluster is a set of registers that are composed into a C data structure in the device header file -->
@@ -546,7 +560,7 @@
         </xs:choice>
       </xs:sequence>
     </xs:sequence>
-    <xs:attribute name="derivedFrom" type="dimableIdentifierType" use="optional"/>
+    <xs:attribute name="derivedFrom" type="referenceIdentifierType" use="optional"/>
   </xs:complexType>
 
   <!-- the registers section can have an arbitrary list of cluster and register sections -->


### PR DESCRIPTION
I'm working on a [SVDSuite](https://github.com/ARMify-Project/SVDSuite), a Python package to parse, process, manipulate, validate, and generate CMSIS SVD files. During development, I noticed a discrepancy between documentation and schema.

According to the documentation, `derivedFrom` can be referenced from another scope for elements `cluster`, `register`, `field`, and `enumeratedValues`. However, in the schema, the type for the `derivedFrom` attribute is `dimableIdentifierType` which does not allow the `.` character. Furthermore, the `enumeratedValue` element in `enumeratedValues` must be specified (`minOccurs` set to 1), which doesn't make sense for deriving. This issue was already reported [here](https://github.com/ARM-software/CMSIS_5/issues/1647).

This PR addresses the described issues. It contains the following changes:
- add referenceIdentifierType (allows `<dimableIdentifierType>.<dimableIdentifierType>` with any depth, but not `.<dimableIdentifierType>`, `.<dimableIdentifierType>.`, or `<dimableIdentifierType>.`)
- change minOccurs for element enumeratedValue from 1 to 0 to allow deriving
- change enumeratedValues derivedFrom attribute type to referenceIdentifierType to allow referencing 
- change field derivedFrom attribute type to referenceIdentifierType to allow referencing from another scope
- change register derivedFrom attribute type to referenceIdentifierType to allow referencing from another scope
- change cluster derivedFrom attribute type to referenceIdentifierType to allow referencing from another scope
- modify svd_schema.txt so that the documentation corresponds to the schema

Please let me know what you think about the PR and if it needs any modifications.