### PR TITLE
correct scope of SVD to Arm Cortex processor-based devices

### DIFF
--- a/doxygen/src/svd.txt
+++ b/doxygen/src/svd.txt
@@ -4,7 +4,7 @@
 Introduction
 ------------
 The CMSIS System View Description format(CMSIS-SVD) formalizes the description of the system
-contained in Arm Cortex-M processor-based microcontrollers, in particular, the memory mapped
+contained in Arm Cortex processor-based devices, in particular, the memory mapped
 registers of peripherals.
 The detail contained in system view descriptions is comparable to the data in device
 reference manuals. The information ranges from high level functional


### PR DESCRIPTION
The SVD specification is generally not limited to Cortex-M but valid for all Arm Cortex processor-based devices.

fixes: #19 